### PR TITLE
[FLAN-538] Add partition to persist certs

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -31,7 +31,7 @@ define(NERVES_FW_ARCHITECTURE, "arm")
 define(NERVES_FW_AUTHOR, "The Nerves Team")
 
 define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
-define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p3") # Linux part number is 1-based
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
 define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
 define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
 
@@ -39,7 +39,7 @@ define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
 define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 
 # This configuration file will create an image that has an MBR and the
-# following 3 partitions:
+# following 4 partitions:
 #
 # +----------------------------+
 # | MBR                        |
@@ -57,7 +57,9 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # +----------------------------+
 # | p1*: Rootfs B (squashfs)   |
 # +----------------------------+
-# | p2: Application (f2fs)     |
+# | p2: Certificates (FAT)     |
+# +----------------------------+
+# | p3: Application (f2fs)     |
 # +----------------------------+
 #
 # The p0/p1 partition points to whichever of configurations A or B that is
@@ -85,9 +87,13 @@ define(ROOTFS_A_PART_COUNT, 289044)
 define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
 define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
 
+# Device certificates partition
+define-eval(CERT_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define(CERT_PART_COUNT, 2048) # 1 MB
+
 # Application partition. This partition can occupy all of the remaining space.
 # Size it to fit the destination.
-define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define-eval(APP_PART_OFFSET, "${CERT_PART_OFFSET} + ${CERT_PART_COUNT}")
 define(APP_PART_COUNT, 1048576)
 
 # Firmware archive metadata
@@ -113,12 +119,16 @@ mbr mbr-a {
         type = 0x83 # Linux
     }
     partition 2 {
+        block-offset = ${CERT_PART_OFFSET}
+        block-count = ${CERT_PART_COUNT}
+        type = 0x1 # FAT12
+    }
+    partition 3 {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
         expand = true
     }
-    # partition 3 is unused
 }
 
 mbr mbr-b {
@@ -134,12 +144,16 @@ mbr mbr-b {
         type = 0x83 # Linux
     }
     partition 2 {
+        block-offset = ${CERT_PART_OFFSET}
+        block-count = ${CERT_PART_COUNT}
+        type = 0x1 # FAT12
+    }
+    partition 3 {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
         expand = true
     }
-    # partition 3 is unused
 }
 
 # Location where installed firmware information is stored.

--- a/fwup.conf
+++ b/fwup.conf
@@ -20,7 +20,7 @@ define(NERVES_FW_ARCHITECTURE, "arm")
 define(NERVES_FW_AUTHOR, "The Nerves Team")
 
 define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
-define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p3") # Linux part number is 1-based
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
 define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
 define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
 define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
@@ -29,7 +29,7 @@ define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.c
 define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 
 # This configuration file will create an image that has an MBR and the
-# following 3 partitions:
+# following 4 partitions:
 #
 # +----------------------------+
 # | MBR                        |
@@ -47,7 +47,9 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # +----------------------------+
 # | p1*: Rootfs B (squashfs)   |
 # +----------------------------+
-# | p2: Application (f2fs)     |
+# | p2: Certificates (FAT)     |
+# +----------------------------+
+# | p3: Application (f2fs)     |
 # +----------------------------+
 #
 # The p0/p1 partition points to whichever of configurations A or B that is
@@ -75,9 +77,13 @@ define(ROOTFS_A_PART_COUNT, 289044)
 define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
 define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
 
+# Device certificates partition
+define-eval(CERT_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define(CERT_PART_COUNT, 2048) # 1 MB
+
 # Application partition. This partition can occupy all of the remaining space.
 # Size it to fit the destination.
-define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define-eval(APP_PART_OFFSET, "${CERT_PART_OFFSET} + ${CERT_PART_COUNT}")
 define(APP_PART_COUNT, 1048576)
 
 # Firmware archive metadata
@@ -159,12 +165,16 @@ mbr mbr-a {
         type = 0x83 # Linux
     }
     partition 2 {
+        block-offset = ${CERT_PART_OFFSET}
+        block-count = ${CERT_PART_COUNT}
+        type = 0x1 # FAT12
+    }
+    partition 3 {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
         expand = true
     }
-    # partition 3 is unused
 }
 
 mbr mbr-b {
@@ -180,12 +190,16 @@ mbr mbr-b {
         type = 0x83 # Linux
     }
     partition 2 {
+        block-offset = ${CERT_PART_OFFSET}
+        block-count = ${CERT_PART_COUNT}
+        type = 0x1 # FAT12
+    }
+    partition 3 {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
         expand = true
     }
-    # partition 3 is unused
 }
 
 # Location where installed firmware information is stored.
@@ -207,6 +221,9 @@ task complete {
         fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
         fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
         fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        fat_mkfs(${CERT_PART_OFFSET}, ${CERT_PART_COUNT})
+        fat_setlabel(${CERT_PART_OFFSET}, "CERT")
 
         uboot_clearenv(uboot-env)
 

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -59,7 +59,8 @@
 #       nerves_runtime will auto-format it. Your applications will need to handle
 #       initializing any expected files and folders.
 -m /dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
--m /dev/mmcblk0p3:/root:f2fs:nodev:
+-m /dev/mmcblk0p3:/etc/ssl/certs:vfat:ro,nodev,noexec,nosuid:
+-m /dev/mmcblk0p4:/root:f2fs:nodev:
 -m pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
 -m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
 -m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu

--- a/rootfs_overlay/etc/ssl/certs/cremini-cert.pem
+++ b/rootfs_overlay/etc/ssl/certs/cremini-cert.pem
@@ -1,0 +1,98 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            42:14:07:96:13:9f:44:41:a8:a6:2b:e5:ab:cb:52:26:70:d7:da:14
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: O = NervesHub, OU = NervesHub Certificate Authority, CN = NervesHub Root CA
+        Validity
+            Not Before: Jul 26 19:19:00 2018 GMT
+            Not After : Jul 18 19:19:00 2048 GMT
+        Subject: O = NervesHub, OU = NervesHub Certificate Authority, CN = NervesHub Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:54:be:fc:e7:87:c0:04:e2:96:68:ce:54:07:9e:
+                    ec:d8:b5:4e:16:d2:e5:40:d3:6b:84:3a:69:68:9a:
+                    bd:c9:90:2e:b5:dd:4b:b2:29:56:32:8e:d6:21:0f:
+                    c8:68:bb:00:35:cf:df:87:89:5a:af:0f:1a:ff:b9:
+                    f5:84:7f:2a:22
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier:
+                EC:6E:F8:90:F5:D3:9C:3C:21:42:FC:83:5B:4D:8D:A5:67:51:DE:60
+    Signature Algorithm: ecdsa-with-SHA256
+         30:46:02:21:00:d3:f0:21:f1:bf:de:ac:eb:fc:dc:24:a3:fd:
+         d9:e4:5d:4b:4d:f3:86:77:7b:c5:ec:8d:48:1e:e3:9b:b8:81:
+         ea:02:21:00:b8:d8:64:60:b1:cc:dc:1f:b3:13:25:79:33:54:
+         ba:dc:04:f4:7e:ac:0a:50:4f:87:98:dd:09:56:fe:17:c6:0f
+-----BEGIN CERTIFICATE-----
+MIIB+TCCAZ6gAwIBAgIUQhQHlhOfREGopivlq8tSJnDX2hQwCgYIKoZIzj0EAwIw
+WjESMBAGA1UEChMJTmVydmVzSHViMSgwJgYDVQQLEx9OZXJ2ZXNIdWIgQ2VydGlm
+aWNhdGUgQXV0aG9yaXR5MRowGAYDVQQDExFOZXJ2ZXNIdWIgUm9vdCBDQTAeFw0x
+ODA3MjYxOTE5MDBaFw00ODA3MTgxOTE5MDBaMFoxEjAQBgNVBAoTCU5lcnZlc0h1
+YjEoMCYGA1UECxMfTmVydmVzSHViIENlcnRpZmljYXRlIEF1dGhvcml0eTEaMBgG
+A1UEAxMRTmVydmVzSHViIFJvb3QgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AARUvvznh8AE4pZozlQHnuzYtU4W0uVA02uEOmlomr3JkC613UuyKVYyjtYhD8ho
+uwA1z9+HiVqvDxr/ufWEfyoio0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
+BAUwAwEB/zAdBgNVHQ4EFgQU7G74kPXTnDwhQvyDW02NpWdR3mAwCgYIKoZIzj0E
+AwIDSQAwRgIhANPwIfG/3qzr/Nwko/3Z5F1LTfOGd3vF7I1IHuObuIHqAiEAuNhk
+YLHM3B+zEyV5M1S63AT0fqwKUE+HmN0JVv4Xxg8=
+-----END CERTIFICATE-----
+
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            a2:07:6c:12:7e:04:a5:8a:dd:2b:0f:8b:11:13:29:cd:60:b4:46:04
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: O = NervesHub, OU = NervesHub Certificate Authority, CN = NervesHub Root CA
+        Validity
+            Not Before: Oct 20 11:00:00 2021 GMT
+            Not After : Oct 20 12:00:00 2031 GMT
+        Subject: O = Peridio, CN = Peridio Server Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:88:c6:e6:74:9a:0e:38:80:24:d5:b6:a3:2d:10:
+                    e0:c4:d8:7f:66:10:47:8b:9d:7c:a6:a3:c7:79:42:
+                    a3:93:9a:44:c9:6b:ea:e1:3c:af:8d:b7:60:c3:08:
+                    0f:c6:63:c4:7a:16:b7:7e:63:f5:db:d2:39:ae:c3:
+                    0b:99:85:44:fe
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier:
+                C3:DA:15:8B:CD:CB:98:AE:09:BA:06:25:9C:72:07:D4:3B:10:39:0D
+            X509v3 Authority Key Identifier:
+                keyid:EC:6E:F8:90:F5:D3:9C:3C:21:42:FC:83:5B:4D:8D:A5:67:51:DE:60
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+    Signature Algorithm: ecdsa-with-SHA256
+         30:46:02:21:00:c7:57:ad:9f:e8:6e:b3:20:1e:2e:27:8a:50:
+         9a:15:4d:ca:3e:79:31:32:b7:cf:4b:1b:b6:5c:9a:e3:ac:08:
+         9d:02:21:00:8e:6b:e5:b1:88:58:e0:b4:b1:51:bf:c6:2f:db:
+         8a:89:a4:e8:a5:a1:06:e4:f9:61:da:aa:56:d2:fc:47:a6:c5
+-----BEGIN CERTIFICATE-----
+MIIB9zCCAZygAwIBAgIVAKIHbBJ+BKWK3SsPixETKc1gtEYEMAoGCCqGSM49BAMC
+MFoxEjAQBgNVBAoTCU5lcnZlc0h1YjEoMCYGA1UECxMfTmVydmVzSHViIENlcnRp
+ZmljYXRlIEF1dGhvcml0eTEaMBgGA1UEAxMRTmVydmVzSHViIFJvb3QgQ0EwHhcN
+MjExMDIwMTEwMDAwWhcNMzExMDIwMTIwMDAwWjAzMRAwDgYDVQQKDAdQZXJpZGlv
+MR8wHQYDVQQDDBZQZXJpZGlvIFNlcnZlciBSb290IENBMFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAEiMbmdJoOOIAk1bajLRDgxNh/ZhBHi518pqPHeUKjk5pEyWvq
+4TyvjbdgwwgPxmPEeha3fmP129I5rsMLmYVE/qNmMGQwDgYDVR0PAQH/BAQDAgGG
+MB0GA1UdDgQWBBTD2hWLzcuYrgm6BiWccgfUOxA5DTAfBgNVHSMEGDAWgBTsbviQ
+9dOcPCFC/INbTY2lZ1HeYDASBgNVHRMBAf8ECDAGAQH/AgEAMAoGCCqGSM49BAMC
+A0kAMEYCIQDHV62f6G6zIB4uJ4pQmhVNyj55MTK3z0sbtlya46wInQIhAI5r5bGI
+WOC0sVG/xi/biomk6KWhBuT5YdqqVtL8R6bF
+-----END CERTIFICATE-----


### PR DESCRIPTION
In order to support continuous delivery across the team, the WLP devices should be able to persist their certificates in the absence of a NervesKey.

The cremini cert is included as a placeholder, but normally the cert partition will be mounted at `/etc/ssl/certs`